### PR TITLE
Add "steps" that Scrape should follow when searching for values on HTML page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Cocoon allows nested fields with simple form
+gem 'cocoon', '1.2.10'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     chromedriver-helper (1.1.0)
       archive-zip (~> 0.7.0)
       nokogiri (~> 1.6)
+    cocoon (1.2.10)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -188,7 +189,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
-    rb-fsevent (0.10.1)
+    rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     record_tag_helper (1.0.0)
@@ -257,6 +258,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3, >= 3.3.4)
   byebug
   chromedriver-helper
+  cocoon (= 1.2.10)
   coffee-rails (~> 4.2)
   delayed_job_active_record
   devise

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require bootstrap
+//= require turbolinks
+//= require cocoon
 //= require_tree .

--- a/app/controllers/scrapes_controller.rb
+++ b/app/controllers/scrapes_controller.rb
@@ -80,6 +80,9 @@ class ScrapesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def scrape_params
-      params.require(:scrape).permit(:name, :user, :url, :xpath, :screenshot, :config_value, :read_value, :status, :last_read)
+      params.require(:scrape).permit(:name, :user, :url, :xpath, :screenshot,
+        :config_value, :read_value, :status, :last_read,
+        scrape_steps_attributes: [:title, :xpath, :option, :value, :_destroy]
+      )
     end
 end

--- a/app/jobs/scrape_data.rb
+++ b/app/jobs/scrape_data.rb
@@ -1,34 +1,22 @@
-class ScrapeData < ApplicationJob
-  require 'telegram/bot'
-  require 'headless'
-  queue_as :default
-  def perform(id)
-    #items = Scrape.where("last_read < ?", 60.minutes.ago)S
-    item = Scrape.find(id)
-    puts item.name
-    puts item.url
+require 'telegram/bot'
+require 'headless'
 
-    last_status = item.status
-    #puts item.xpath
-    #switches = ['--proxy=69.106.88.7:60199', '--proxy-auth=username:password123']
-    #browser = Watir::Browser.new :phantomjs, :args => switches
-    #proxyFileName = "proxynow.txt"
-    #file_content = File.read("public/#{proxyFileName}");
-    #puts file_content;
+class ScrapeData < ApplicationJob
+  queue_as :default
+
+  def perform(id)
+    item = Scrape.find(id)
+
+    puts "Scraping -> #{item.name} -> URL: #{item.url}"
 
     proxy = "#{Setting.proxyIp}:#{Setting.proxyPort}"
+    last_status = item.status
 
     puts "using proxy: #{proxy}"
 
     headless = Headless.new
     headless.start
 
-    #Selenium::WebDriver::PhantomJS.path="./bin/phantomjs"
-    # browser = Watir::Browser.new( :chrome,
-    #     args: "--proxy=#{proxy}"
-    # )
-
-    Selenium::WebDriver::Chrome.path = '/usr/bin/google-chrome'
     options = Selenium::WebDriver::Chrome::Options.new
     options.add_argument('--user-data-dir=./tmp')
     options.add_argument('--ignore-certificate-errors')
@@ -36,23 +24,14 @@ class ScrapeData < ApplicationJob
     options.add_argument('--disable-translate')
     options.add_argument('--no-sandbox')
     options.add_argument("--proxy-server=#{proxy}")
-    driver = Selenium::WebDriver.for :chrome, options: options
-
-    browser = Watir::Browser.new driver
-    #browser = Watir::Browser.new( :chrome, desired_capabilities: %w(--headless --disable-gpu --start-maximized --disable-web-security --disable-extensions --ignore-certificate-errors --disable-popup-blocking --disable-translate --proxy-server=m#{proxy}))
 
     Watir.default_timeout = 180
-    #browser.window.maximize
+    @browser = Watir::Browser.new(Selenium::WebDriver.for(:chrome, options: options))
 
-    filename = DateTime.now.strftime("%d%b%Y%H%M%S")
-
-    # browser.goto(item.url)
-    # sleep 20
     tryLeft = 3
     begin
-      puts "lets go to!"
-      browser.goto(item.url)
-      #browser.element(:xpath => item.xpath).wait_until_present(timeout=120)
+      puts "lets go to! #{item.url}"
+      @browser.goto(item.url)
     rescue => error
       tryLeft -= 1
       puts "something went wrong! #{error}"
@@ -60,59 +39,84 @@ class ScrapeData < ApplicationJob
         sleep 5
         retry
       end
-      browser.quit
+      @browser.quit
       headless.destroy
     end
 
     tryLeft = 6
     loop do
       tryLeft -= 1
-      puts "lets search for the element now!"
       sleep 10
-      break if browser.element(:xpath => item.xpath).present? || tryLeft <= 0
+      puts "lets search for the element now!"
+      break if @browser.element(:xpath => item.xpath).present? || tryLeft <= 0
     end
 
-    #browser.wait_until(15) { browser.h1.text != 'Main Page' }
-    #browser.wait_until(60) { browser.text_field.exists? }
-    #browser.element(:xpath => item.xpath).wait_until_present(timeout=20)
+    if(item.screenshot?)
+      File.delete("public/screenshots/#{item.screenshot}") if File.exist?("public/screenshots/#{item.screenshot}")
+    end
 
-      if(item.screenshot?)
-        File.delete("public/screenshots/#{item.screenshot}") if File.exist?("public/screenshots/#{item.screenshot}")
+    filename = DateTime.now.strftime("%d%b%Y%H%M%S")
+    @browser.screenshot.save("public/screenshots/#{filename}.png")
+    item.screenshot = "#{filename}.png"
+
+    # Before read the final value, run the previous steps
+    execute_steps(item.scrape_steps) if item.scrape_steps.any?
+    page_html = Nokogiri::HTML.parse(@browser.html)
+    # Now read the goal value
+    read_value = page_html.xpath(item.xpath).inner_text
+    puts read_value
+
+    # Assign the correct value for the Scrape
+    item.read_value = read_value
+    item.last_read = DateTime.now
+
+    # Check if goal value has changed
+    if item.config_value.strip == item.read_value.strip
+      item.status = 1
+      puts "similar"
+    elsif item.read_value.strip == ''
+      item.status = 3
+      puts "not found"
+    else
+      item.status = 2
+      puts "changed"
+    end
+
+    if (item.status != 1 && item.status != last_status )
+      if(item.user.telegramId.present?) #if telegramid not set, dont try to message with warning
+        Telegram.bot.send_message chat_id: item.user.telegramId, text: "<b>Warning!</b> \nThe scrape <b>#{item.name}</b> \nNew status is <b>#{item.status}</b> \nTake a look at: #{item.url}", parse_mode: :HTML
       end
-      browser.screenshot.save ("public/screenshots/#{filename}.png")
-      #file = File.new("public/html/#{filename}.html", "w")
-      #file.puts(browser.html)
-      #file.close
+    end
 
-      item.screenshot = "#{filename}.png"
-
-      page_html = Nokogiri::HTML.parse(browser.html)
-      puts page_html.xpath(item.xpath).inner_text
-
-      read_value = page_html.xpath(item.xpath).inner_text
-
-      item.read_value = read_value
-      item.last_read = DateTime.now
-
-      if item.config_value.strip == item.read_value.strip
-        item.status = 1
-        puts "similar"
-      elsif item.read_value.strip == ''
-        item.status = 3
-        puts "not found"
-      else
-        item.status = 2
-        puts "changed"
-      end
-
-      if (item.status != 1 && item.status != last_status )
-        if(item.user.telegramId.present?) #if telegramid not set, dont try to message with warning
-          Telegram.bot.send_message chat_id: item.user.telegramId, text: "<b>Warning!</b> \nThe scrape <b>#{item.name}</b> \nNew status is <b>#{item.status}</b> \nTake a look at: #{item.url}", parse_mode: :HTML
-        end
-      end
-
-      item.save
-    browser.quit
+    # Save and finish browser
+    item.save
+    @browser.quit
     headless.destroy
+  end
+
+  private
+
+  def execute_steps(steps)
+    puts "Executing Steps..."
+    steps.each do |step|
+      click(step.xpath) if step.option == 'click'
+      select(step.xpath, step.value) if step.option == 'select value'
+      fill_in(step.xpath, step.value) if step.option == 'fill in'
+    end
+  end
+
+  def click(xpath)
+    puts "Clicking on '#{xpath}'"
+    @browser.element(:xpath, xpath).click
+  end
+
+  def fill_in(xpath, value)
+    puts "Filling '#{value}' on '#{xpath}'"
+    @browser.text_field(xpath: xpath).set(value)
+  end
+
+  def select(xpath, value)
+    puts "Selecting '#{value}' on '#{xpath}'"
+    @browser.select_list(:xpath, xpath).option(text: value).select
   end
 end

--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -1,12 +1,18 @@
 class Scrape < ApplicationRecord
+  extend Enumerize
 
   belongs_to :user
 
-  extend Enumerize
-  enumerize :status, :in => {
-    :unscraped => 0,
-    :similar => 1,
-    :changed => 2,
-    :notfound => 3
-    }, default: :unscraped, scope: true
+  has_many :scrape_steps, dependent: :destroy, inverse_of: :scrape
+
+  accepts_nested_attributes_for :scrape_steps, allow_destroy: true
+
+  validates :name, :url, :xpath, :config_value, :user_id, presence: true
+
+  enumerize :status, in: {
+    unscraped: 0,
+    similar: 1,
+    changed: 2,
+    notfound: 3
+  }, default: :unscraped, scope: true
 end

--- a/app/models/scrape_step.rb
+++ b/app/models/scrape_step.rb
@@ -1,0 +1,6 @@
+class ScrapeStep < ApplicationRecord
+  belongs_to :scrape, inverse_of: :scrape_steps
+
+  validates :title, :xpath, :option, presence: true
+  validates :value, presence: true, if: "option == 'select value'"
+end

--- a/app/views/scrapes/_form.html.erb
+++ b/app/views/scrapes/_form.html.erb
@@ -7,8 +7,18 @@
     <%= f.input :xpath %>
     <%= f.input :config_value %>
     <%= f.input :read_value %>
-    <%= f.input :status, :as => :hidden, :input_html => { :value => 0 } %>
+    <%= f.input :status, as: :hidden, input_html: { value: 0 } %>
+  </div>
 
+  <h3>STEPS (if your Scrape requires interaction with forms or something)</h3>
+
+  <div id="scrape_steps">
+    <%= f.simple_fields_for :scrape_steps do |scrape_step| %>
+      <%= render 'scrape_step_fields', f: scrape_step %>
+    <% end %>
+    <div class="links">
+      <%= link_to_add_association 'Add Step', f, :scrape_steps, class: 'btn btn-success' %>
+    </div>
   </div>
 
   <div class="form-actions">

--- a/app/views/scrapes/_scrape_step_fields.html.erb
+++ b/app/views/scrapes/_scrape_step_fields.html.erb
@@ -1,0 +1,7 @@
+<div class="nested-fields">
+  <%= f.input :title %>
+  <%= f.input :xpath %>
+  <%= f.input :option, collection: ['click', 'select value', 'fill in'] %>
+  <%= f.input :value %>
+  <%= link_to_remove_association 'Remove Step', f %>
+</div>

--- a/app/views/scrapes/index.html.erb
+++ b/app/views/scrapes/index.html.erb
@@ -10,38 +10,38 @@
   <table class="table table-striped table-bordered table-hover">
     <thead>
       <tr>
-            <th>Name</th>
-            <th>Url</th>
-            <th>Status</th>
-            <th>Last read</th>
-            <th>Config value</th>
-            <th>Read value</th>
-            <th>Screenshot</th>
+        <th>Name</th>
+        <th>Url</th>
+        <th>Status</th>
+        <th>Last read</th>
+        <th>Config value</th>
+        <th>Read value</th>
+        <th>Screenshot</th>
       </tr>
     </thead>
 
     <tbody>
       <%= content_tag_for(:tr, @scrapes) do |scrape| %>
-            <td><%= scrape.name %></td>
-            <td><%= link_to "Link", scrape.url, target: "_blank" %></td>
-            <td><h4><span class="label
-              <% if scrape.status.similar? %>
-                label-success
-              <% elsif scrape.status.changed? %>
-                label-warning
-              <% elsif scrape.status.unscraped? %>
-                  label-primary
-                <% else %>
-                label-danger
-              <% end %>
-              "><%= scrape.status.text %></span></h4>
-            </td>
-            <td><%= time_ago_in_words(scrape.last_read) if scrape.last_read %></td>
-            <td><%= scrape.config_value %></td>
-            <td><%= scrape.read_value %></td>
-            <td><%= link_to "Open", "/screenshots/#{scrape.screenshot}", target: "_blank" if scrape.screenshot %></td>
-            <td><%= link_to 'Scrape', scrape_scrape_path(scrape), method: :post %></td>
-            <td><%= link_to 'Show', scrape %></td>
+        <td><%= scrape.name %></td>
+        <td><%= link_to "Link", scrape.url, target: "_blank" %></td>
+        <td><h4><span class="label
+          <% if scrape.status.similar? %>
+            label-success
+          <% elsif scrape.status.changed? %>
+            label-warning
+          <% elsif scrape.status.unscraped? %>
+              label-primary
+            <% else %>
+            label-danger
+          <% end %>
+          "><%= scrape.status.text %></span></h4>
+        </td>
+        <td><%= time_ago_in_words(scrape.last_read) if scrape.last_read %></td>
+        <td><%= scrape.config_value %></td>
+        <td><%= scrape.read_value %></td>
+        <td><%= link_to "Open", "/screenshots/#{scrape.screenshot}", target: "_blank" if scrape.screenshot %></td>
+        <td><%= link_to 'Scrape', scrape_scrape_path(scrape), method: :post %></td>
+        <td><%= link_to 'Show', scrape %></td>
         <td><%= link_to 'Edit', edit_scrape_path(scrape) %></td>
         <td><%= link_to 'Destroy', scrape, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       <% end %>
@@ -53,21 +53,21 @@
   <table class="table table-striped table-bordered table-hover">
     <thead>
       <tr>
-            <th>Priority</th>
-            <th>attempts</th>
-            <th>handler</th>
-            <th>last_error</th>
-            <th>run_at</th>
+        <th>Priority</th>
+        <th>attempts</th>
+        <th>handler</th>
+        <th>last_error</th>
+        <th>run_at</th>
       </tr>
     </thead>
 
     <tbody>
       <%= content_tag_for(:tr, @jobs) do |job| %>
-            <td><%= job.priority %></td>
-            <td><%= job.attempts %></td>
-            <td><%= job.handler %></td>
-            <td><%= job.last_error %></td>
-            <td><%= distance_of_time_in_words(job.run_at, Time.now, include_seconds: true)  %></td>
+        <td><%= job.priority %></td>
+        <td><%= job.attempts %></td>
+        <td><%= job.handler %></td>
+        <td><%= job.last_error %></td>
+        <td><%= distance_of_time_in_words(job.run_at, Time.now, include_seconds: true)  %></td>
       <% end %>
     </tbody>
   </table>

--- a/app/views/scrapes/show.html.erb
+++ b/app/views/scrapes/show.html.erb
@@ -31,5 +31,11 @@
 
   <dt>Last read:</dt>
   <dd><%= @scrape.last_read %></dd>
+</dl>
 
+<dl class="dl-horizontal">
+  <% @scrape.scrape_steps.each_with_index do |step, index| %>
+    <dt>Step <%= index+1 %>:</dt>
+    <dd><%= step.title %></dd>
+  <% end %>
 </dl>

--- a/db/migrate/20170708021133_create_scrape_steps.rb
+++ b/db/migrate/20170708021133_create_scrape_steps.rb
@@ -1,0 +1,13 @@
+class CreateScrapeSteps < ActiveRecord::Migration[5.0]
+  def change
+    create_table :scrape_steps do |t|
+      t.references :scrape, index: true
+      t.string :title, null: false, default: ''
+      t.string :xpath, null: false, default: ''
+      t.string :option, default: ''
+      t.string :value, null: false, default: ''
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170702054259) do
+ActiveRecord::Schema.define(version: 20170708021133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,17 @@ ActiveRecord::Schema.define(version: 20170702054259) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+  end
+
+  create_table "scrape_steps", force: :cascade do |t|
+    t.integer  "scrape_id"
+    t.string   "title",      default: "", null: false
+    t.string   "xpath",      default: "", null: false
+    t.string   "option",     default: "", null: false
+    t.string   "value",      default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.index ["scrape_id"], name: "index_scrape_steps_on_scrape_id", using: :btree
   end
 
   create_table "scrapes", force: :cascade do |t|

--- a/test/fixtures/scrape_steps.yml
+++ b/test/fixtures/scrape_steps.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  xpath: MyString
+  option: MyString
+  value: MyString
+
+two:
+  title: MyString
+  xpath: MyString
+  option: MyString
+  value: MyString

--- a/test/models/scrape_step_test.rb
+++ b/test/models/scrape_step_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ScrapeStepTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Now you can set "steps" that Scrape will follow before searching for the final value on page. This can be useful when you need to Select and Option of dropdown, or click on links on the page.
The supported actions for the moment are:
- Fill text field
- Choose options on "select" field
- Click on buttons/links